### PR TITLE
Make terminal content `inline` by default

### DIFF
--- a/components/whyd/2022/Chat/Text.vue
+++ b/components/whyd/2022/Chat/Text.vue
@@ -238,6 +238,10 @@ function parseEmoji(data) {
   white-space: normal;
 }
 
+.parsed-text .block {
+  display: block;
+}
+
 .parsed-text .terminal-emoji img {
   vertical-align: -15%;
   filter: sepia(0.6) brightness(0.9);

--- a/components/whyd/2022/Terminal.vue
+++ b/components/whyd/2022/Terminal.vue
@@ -15,8 +15,8 @@
           <Whyd2022ChatText
             v-for="(line, idx) of text.content.split('\n')"
             :key="idx"
-            style="display: block"
             :content="line"
+            :class="text.block ? 'block' : ''"
           />
           <img
             v-if="text.type === 'image'"
@@ -178,6 +178,10 @@ export default {
   color: var(--primary);
   width: 50px;
   height: 50px;
+}
+
+.block {
+  display: block;
 }
 
 .terminal-image {

--- a/components/whyd/2022/Terminal.vue
+++ b/components/whyd/2022/Terminal.vue
@@ -25,6 +25,11 @@
             :height="text?.height ?? '100px'"
             class="terminal-image"
           />
+          <Whyd2022ChatText
+            v-if="text.lastLineInCommand"
+            :key="`last${text.id}`"
+            content="{End of Command | underline block}"
+          />
         </div>
         <Whyd2022TerminalUserInputArea
           ref="inputArea"

--- a/components/whyd/2022/Terminal/Commands.vue
+++ b/components/whyd/2022/Terminal/Commands.vue
@@ -21,6 +21,7 @@ export default {
         },
         {
           content: `'ls'          - List executables in current directory\n'cd ..'       - Navigate one directory up\n'cd [folder]' - Navigate to [folder]\n'dir'         - Display current directory `,
+          block: true,
         },
         {
           content:
@@ -43,9 +44,13 @@ export default {
             '{@secuityBot4891#1995 Direct Message logs... | underline}\n',
         },
         {
-          content: `This image was sent {${numWalter} | bold} times by {${differentWalterUsers} | bold} users.`,
+          content: '',
           type: 'image',
+          block: true,
           url: 'https://media.tenor.com/S_to1tY3ixUAAAAd/breaking-bad-walter-white.gif',
+        },
+        {
+          content: `This image was sent {${numWalter} | bold} times by {${differentWalterUsers} | bold} users.`,
         },
       ]
 
@@ -784,8 +789,8 @@ export default {
         {
           content: `{> | ethan}`,
           type: 'image',
-          height: '169px',
-          width: '550px',
+          height: '', // automatically determine height
+          width: '500px',
           url: '/whyd/2022/xkdc.png',
         },
         { content: `{> True | ben }` },
@@ -836,7 +841,7 @@ export default {
           width: '363px',
           url: '/whyd/2022/gitcommit.png',
         },
-        { content: `{> | ethan}{:imstuff.webp: | terminal-emoji}` },
+        { content: `{>  | ethan}{:imstuff.webp: | terminal-emoji}` },
         { content: `{> I love writing helpful commit messages | ethan }` },
       ]
     },
@@ -1040,7 +1045,7 @@ export default {
         { content: `{  Us Bot: Error: specified user does not exist | josh}` },
         { content: `{>  | ethan}{:fear: | terminal-emoji}` },
         {
-          content: `{Mr Sloan: I feel like its because I misspelled 'secuity' | josh}`,
+          content: `{  Mr Sloan: I feel like its because I misspelled 'secuity' | josh}`,
         },
         { content: `{> wait | ethan}` },
         { content: `{> Wtf | ethan}` },

--- a/components/whyd/2022/Terminal/PasswordInputArea.vue
+++ b/components/whyd/2022/Terminal/PasswordInputArea.vue
@@ -60,6 +60,7 @@ export default {
       this.$refs.passwordTextInput.disabled = true
       if (this.validPasswords.includes(inputText)) {
         this.correctPassword = true
+        if (inputText === 'f') this.introAnimationTime = 100
         this.showLoggingIn()
       } else if (this.attempts === 3) {
         this.promptText = 'Too many attempts - Locking terminal...'

--- a/components/whyd/2022/Terminal/UserInputArea.vue
+++ b/components/whyd/2022/Terminal/UserInputArea.vue
@@ -420,19 +420,8 @@ export default {
       // lines.push({ content: '{End of Command | underline}' })
       this.terminalLinesQueue = lines.reverse()
 
-      if (lines[0].type === 'image') {
-        lines.splice(0, 0, {
-          content: '\n{End of Command | underline}',
-          block: true,
-        })
-      } else {
-        lines[0] = {
-          ...lines[0],
-          content: lines[0].content.concat(
-            '\n{End of Command | underline block}',
-          ),
-        }
-      }
+      lines[0].lastLineInCommand = true
+
       this.terminalMode = mode.clickContinue
       this.isShowProceed = true
       this.handleContinueButtonClick()

--- a/components/whyd/2022/Terminal/UserInputArea.vue
+++ b/components/whyd/2022/Terminal/UserInputArea.vue
@@ -332,6 +332,7 @@ export default {
           .join(', ')
         this.emitNewLine({
           content: `{Current Directory | underline}\n~${this.path}\n{Availible Executables | underline}\n${list}\n`,
+          block: true,
         })
         this.addToCommandHistory(commandName)
         return
@@ -351,7 +352,7 @@ export default {
         return
       }
 
-      addToCommandHistory(commandName)
+      this.addToCommandHistory(commandName)
       this.emitNewLine({
         content: `{Error: Command not found '${commandName}' | error}`,
       })
@@ -418,9 +419,19 @@ export default {
       // takes a list of processed text lines and puts the terminal in clickContinue mode to read through them
       // lines.push({ content: '{End of Command | underline}' })
       this.terminalLinesQueue = lines.reverse()
-      lines[0] = {
-        ...lines[0],
-        content: lines[0].content.concat('\n{End of Command | underline}'),
+
+      if (lines[0].type === 'image') {
+        lines.splice(0, 0, {
+          content: '\n{End of Command | underline}',
+          block: true,
+        })
+      } else {
+        lines[0] = {
+          ...lines[0],
+          content: lines[0].content.concat(
+            '\n{End of Command | underline block}',
+          ),
+        }
       }
       this.terminalMode = mode.clickContinue
       this.isShowProceed = true


### PR DESCRIPTION
All text things used to have `style="display: block;"`, but that has been replaced with a class called `block` that you can add to the lines objects: `block: true`. I've also added a block class in `Text` in case you need more granularity.

This PR also fixes a regression in the DMs command where the image was showing up beneath both "This image has been sent..." and "End of command"